### PR TITLE
Chore: Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ apply plugin: 'de.mobilej.unmock'
 apply plugin: 'kotlin-android'
 
 buildscript {
-    ext.retrofit_version = '2.3.0'
+    ext.retrofit_version = '2.9.0'
+    ext.kotlin_version = '1.4.21'
 
     repositories {
         jcenter()
@@ -56,32 +57,32 @@ android {
 
 dependencies {
 
-    api 'androidx.core:core:1.2.0' // required for FileProvider and Annotations
+    api 'androidx.core:core-ktx:1.3.2' // required for FileProvider and Annotations
 
     // ReactiveX
     api 'io.reactivex.rxjava2:rxandroid:2.1.1' // rxjava (observables)
-    api 'io.reactivex.rxjava2:rxjava:2.2.11' // RxAndroid releases are few and far between, so depend on latest version for bug fixes and new features
+    api 'io.reactivex.rxjava2:rxjava:2.2.19' // RxAndroid releases are few and far between, so depend on latest version for bug fixes and new features
 
     // network
-    api "com.squareup.retrofit2:retrofit:$retrofit_version" // http requests
-    api "com.squareup.retrofit2:converter-gson:$retrofit_version" // json parsing
-    api "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version" // retrofit with observables
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version" // http requests
+    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version" // json parsing
+    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version" // retrofit with observables
     api 'com.squareup.picasso:picasso:2.71828' // ion provides a picasso wrapper adding an authorization header to requests
-    implementation 'androidx.exifinterface:exifinterface:1.2.0' // ensure picasso's dependency to support library is up-to-date
+    implementation 'androidx.exifinterface:exifinterface:1.3.2' // ensure picasso's dependency to support library is up-to-date
 
     // misc
     implementation 'org.apache.commons:commons-compress:1.12'
     api 'net.danlew:android.joda:2.10.6' // better DateTime handling
 
-    testApi 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-    testApi "org.jetbrains.spek:spek:1.0.25"
-    testApi "nl.jqno.equalsverifier:equalsverifier:3.1.9"
+    testImplementation "org.jetbrains.spek:spek:1.0.25"
+    testImplementation "nl.jqno.equalsverifier:equalsverifier:3.1.9"
 
     androidTestImplementation 'androidx.annotation:annotation:1.1.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
 
     unmock 'org.robolectric:android-all:4.3_r2-robolectric-0'
 }

--- a/src/main/java/com/anfema/ionclient/archive/IonArchiveDownloader.java
+++ b/src/main/java/com/anfema/ionclient/archive/IonArchiveDownloader.java
@@ -74,7 +74,7 @@ class IonArchiveDownloader implements IonArchive, CollectionDownloadedListener
 	 * @param inCollection If collection already is available it can be passed in order to save time.
 	 * @param lastModified when the collection has been last modified
 	 */
-	public Completable downloadArchive( Collection inCollection, String lastModified )
+	private Completable downloadArchive( Collection inCollection, String lastModified )
 	{
 		if ( inCollection != null && !inCollection.identifier.equals( config.collectionIdentifier ) )
 		{


### PR DESCRIPTION
Do not rely on compile, target, and  library versions being set in app anymore

re #171 