### PR TITLE
Inspect tar file

### DIFF
--- a/src/main/java/com/anfema/ionclient/archive/ArchiveUtils.kt
+++ b/src/main/java/com/anfema/ionclient/archive/ArchiveUtils.kt
@@ -34,6 +34,10 @@ import java.io.IOException
 import java.io.InputStreamReader
 import java.util.LinkedList
 
+// set to true in production
+// set to false in debug builds to inspect the TAR file
+private const val DELETE_ARCHIVE_FILE = true
+
 internal object ArchiveUtils {
     private const val TAG = "ArchiveUtils"
 
@@ -225,8 +229,10 @@ internal object ArchiveUtils {
         // add archive to file cache again - not the actual file, but the last updated information is required for subsequent archive downloads
         if (archiveFile.exists() && collection.archive != null) {
             FileCacheIndex.save(collection.archive, archiveFile, collectionProperties, null, requestTime, context)
-            // delete archiveFile - yes that introduces an inconsistency, but it saves storage space on the other side
-            archiveFile.delete()
+            if (DELETE_ARCHIVE_FILE) {
+                // delete archiveFile - yes that introduces an inconsistency, but it saves storage space on the other side
+                archiveFile.delete()
+            }
         } else {
             val archiveFilePath = archiveFile.path
             IonLog.e(

--- a/src/main/java/com/anfema/ionclient/archive/ArchiveUtils.kt
+++ b/src/main/java/com/anfema/ionclient/archive/ArchiveUtils.kt
@@ -237,6 +237,8 @@ internal object ArchiveUtils {
             if (DELETE_ARCHIVE_FILE) {
                 // delete archiveFile - yes that introduces an inconsistency, but it saves storage space on the other side
                 archiveFile.delete()
+            } else {
+                IonLog.i(TAG, "Archive file path: ${archiveFile.path}")
             }
         } else {
             val archiveFilePath = archiveFile.path

--- a/src/main/java/com/anfema/ionclient/archive/ArchiveUtils.kt
+++ b/src/main/java/com/anfema/ionclient/archive/ArchiveUtils.kt
@@ -131,8 +131,12 @@ internal object ArchiveUtils {
                                 // get index.json
                                 val inputStreamReader = InputStreamReader(debInputStream, "UTF-8")
                                 archiveIndexes =
-                                    listOf(*GsonHolder.defaultInstance.fromJson(inputStreamReader,
-                                        Array<ArchiveIndex>::class.java))
+                                    listOf(
+                                        *GsonHolder.defaultInstance.fromJson(
+                                            inputStreamReader,
+                                            Array<ArchiveIndex>::class.java
+                                        )
+                                    )
                                 indexHasBeenRead = true
                                 continue
                             }
@@ -186,8 +190,9 @@ internal object ArchiveUtils {
                 }
 
                 if (untaredFile.file.exists() && entriesWithSameIdentifier > 1) {
-                    IonLog.w("FileMoveException", "URL: " + untaredFile.originUrl
-                        + ", ignore it because it was probably caused by the file being duplicated in the TAR file."
+                    IonLog.w(
+                        "FileMoveException", "URL: " + untaredFile.originUrl
+                            + ", ignore it because it was probably caused by the file being duplicated in the TAR file."
                     )
                 } else {
                     IonLog.e("FileMoveException", "URL: " + untaredFile.originUrl)


### PR DESCRIPTION
Facilitate TAR file inspection:
If `DELETE_ARCHIVE_FILE` is set to `false` then the TAR file is kept in the local file storage.